### PR TITLE
Use Fabric Transfer API for Passer

### DIFF
--- a/src/main/java/net/fxnt/fxntstorage/passer/PasserEntity.java
+++ b/src/main/java/net/fxnt/fxntstorage/passer/PasserEntity.java
@@ -1,10 +1,11 @@
 package net.fxnt.fxntstorage.passer;
 
+import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
+import net.fabricmc.fabric.api.transfer.v1.storage.StorageUtil;
 import net.fxnt.fxntstorage.init.ModBlocks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.world.Container;
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -22,6 +23,7 @@ public class PasserEntity extends BlockEntity {
         this.facing = this.getBlockState().getValue(FACING);
     }
 
+    @SuppressWarnings("UnstableApiUsage")
     public <T extends BlockEntity> void serverTick(Level level, BlockPos blockPos, BlockEntity blockEntity) {
         if (level != null && !level.isClientSide) {
             lastTick++;
@@ -33,20 +35,18 @@ public class PasserEntity extends BlockEntity {
             doTick = false;
 
             this.facing = this.getBlockState().getValue(FACING);
-            Container srcContainer = PasserHelper.getContainer(level, blockPos, this.facing, true);
+            Storage<ItemVariant> srcContainer = PasserHelper.getStorage(level, blockPos, this.facing, true);
             if (srcContainer == null) {
                 return;
             }
-            Container dstContainer = PasserHelper.getContainer(level, blockPos, this.facing, false);
+            Storage<ItemVariant> dstContainer = PasserHelper.getStorage(level, blockPos, this.facing, false);
             if (dstContainer == null) {
                 return;
             }
 
-            ItemStack filterItem = ItemStack.EMPTY;
             int amount = 1;
-            boolean fixedAmount = false;
 
-            PasserHelper.passItems(level, srcContainer, dstContainer, this.facing, amount, fixedAmount, filterItem); // Set to limit set by filter
+            StorageUtil.move(srcContainer, dstContainer, variant -> true, amount, null);
         }
     }
 

--- a/src/main/java/net/fxnt/fxntstorage/passer/PasserHelper.java
+++ b/src/main/java/net/fxnt/fxntstorage/passer/PasserHelper.java
@@ -1,6 +1,9 @@
 package net.fxnt.fxntstorage.passer;
 
 import com.simibubi.create.content.logistics.filter.FilterItemStack;
+import net.fabricmc.fabric.api.transfer.v1.item.ItemStorage;
+import net.fabricmc.fabric.api.transfer.v1.item.ItemVariant;
+import net.fabricmc.fabric.api.transfer.v1.storage.Storage;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.Container;
@@ -18,6 +21,21 @@ import org.jetbrains.annotations.Nullable;
 import java.util.stream.IntStream;
 
 public class PasserHelper {
+    @SuppressWarnings("UnstableApiUsage")
+    @Nullable
+    public static Storage<ItemVariant> getStorage(Level level, BlockPos blockPos, Direction facing, boolean source) {
+        BlockPos containerPos;
+        Direction interactSide;
+        if (source) {
+            containerPos = blockPos.relative(facing.getOpposite());
+            interactSide = facing;
+        } else {
+            containerPos = blockPos.relative(facing);
+            interactSide = facing.getOpposite();
+        }
+
+        return ItemStorage.SIDED.find(level, containerPos, interactSide);
+    }
 
     @Nullable
     public static Container getContainer(Level level, BlockPos blockPos, Direction facing, boolean source) {


### PR DESCRIPTION
As I already said in #4, using Fabric Transfer API for moving items would make the Passer more compatible with other mods. This pull request does exactly that. It also makes a lot of code in PasserHelper obsolete, however, I have not yet removed it.