### PR TITLE
Fix for storage boxes with Index 0 out of bounds for length 0

### DIFF
--- a/src/main/java/net/fxnt/fxntstorage/containers/StorageBoxEntity.java
+++ b/src/main/java/net/fxnt/fxntstorage/containers/StorageBoxEntity.java
@@ -187,7 +187,7 @@ public class StorageBoxEntity extends SmartBlockEntity implements WorldlyContain
     @Override
     public int @NotNull [] getSlotsForFace(Direction side) {
         initializeSlotsForAllDirections();
-        if (SLOTS_FOR_ALL_DIRECTIONS.length < 1) return new int[]{0};
+        if (SLOTS_FOR_ALL_DIRECTIONS.length < 1) return new int[]{};
         return SLOTS_FOR_ALL_DIRECTIONS;
     }
 


### PR DESCRIPTION
This fixes https://github.com/foxynotail/create-storage-mod-fabric/issues/24

When there where no slots present `getSlotsForFace` would still return an array indicating that face 0 was present. I changed this to return an empty array and this seems to fix the issue.

A problem I noticed is that Storage Boxes need to be picked up and placed again to work if pasted in creative mode using a Create schematic. Perhaps there is an underlying issue with the initialization that is causing this?
