### PR TITLE
Translation files for pt-br and es-ar

### DIFF
--- a/src/main/resources/assets/fxntstorage/lang/es_ar.json
+++ b/src/main/resources/assets/fxntstorage/lang/es_ar.json
@@ -1,0 +1,126 @@
+{
+  "itemGroup.fxntstorage.main": "FXNT Storage",
+  "itemGroup.fxntstorage.create": "FXNT Storage Create",
+
+  "key.categories.fxntstorage": "FXNT Storage",
+  "key.fxntstorage.open_backpack": "Abrir Mochila",
+  "key.fxntstorage.clear_backpack_shape_cache": "Limpar Caché de Forma de la Mochila",
+  "key.fxntstorage.backpack_hover": "Conmutar el Modo de Vuelo de la Mochila",
+  "key.fxntstorage.toggle_upgrade": "Conmutar Mejora",
+
+  "block.fxntstorage.storage_box": "Caja de Almacenamiento de Hierro Industrial",
+  "container.fxntstorage.industrial_iron_storage_box": "Caja de Almacenamiento de Hierro Industrial",
+
+  "block.fxntstorage.andesite_storage_box": "Caja de Almacenamiento de Andesita",
+  "container.fxntstorage.andesite_storage_box": "Caja de Almacenamiento de Andesita",
+
+  "block.fxntstorage.copper_storage_box": "Caja de Almacenamiento de Cobre",
+  "container.fxntstorage.copper_storage_box": "Caja de Almacenamiento de Cobre",
+
+  "block.fxntstorage.brass_storage_box": "Caja de Almacenamiento de Latón",
+  "container.fxntstorage.brass_storage_box": "Caja de Almacenamiento de Latón",
+
+  "block.fxntstorage.hardened_storage_box": "Caja de Almacenamiento Endurecida",
+  "container.fxntstorage.hardened_storage_box": "Caja de Almacenamiento Endurecida",
+
+  "block.fxntstorage.simple_storage_box": "Caja de Almacenamiento Simple de Roble",
+  "container.fxntstorage.simple_storage_box": "Caja de Almacenamiento Simple de Roble",
+
+  "block.fxntstorage.simple_storage_box_spruce": "Caja de Almacenamiento Simple de Abeto",
+  "container.fxntstorage.simple_storage_box_spruce": "Caja de Almacenamiento Simple de Abeto",
+
+  "block.fxntstorage.simple_storage_box_birch": "Caja de Almacenamiento Simple de Abedul",
+  "container.fxntstorage.simple_storage_box_birch": "Caja de Almacenamiento Simple de Abedul",
+
+  "block.fxntstorage.simple_storage_box_jungle": "Caja de Almacenamiento Simple de la Jungla",
+  "container.fxntstorage.simple_storage_box_jungle": "Caja de Almacenamiento Simple de la Jungla",
+
+  "block.fxntstorage.simple_storage_box_acacia": "Caja de Almacenamiento Simple de Acacia",
+  "container.fxntstorage.simple_storage_box_acacia": "Caja de Almacenamiento Simple de Acacia",
+
+  "block.fxntstorage.simple_storage_box_dark_oak": "Caja de Almacenamiento Simple de Roble Oscuro",
+  "container.fxntstorage.simple_storage_box_dark_oak": "Caja de Almacenamiento Simple de Oscuro",
+
+  "block.fxntstorage.simple_storage_box_mangrove": "Caja de Almacenamiento Simple de Mangle",
+  "container.fxntstorage.simple_storage_box_mangrove": "Caja de Almacenamiento Simple de Mangle",
+
+  "block.fxntstorage.simple_storage_box_cherry": "Caja de Almacenamiento Simple de Cerezo",
+  "container.fxntstorage.simple_storage_box_cherry": "Caja de Almacenamiento Simple de Cerezo",
+
+  "block.fxntstorage.simple_storage_box_bamboo": "Caja de Almacenamiento Simple de Bambú",
+  "container.fxntstorage.simple_storage_box_bamboo": "Caja de Almacenamiento Simple de Bambú",
+
+  "block.fxntstorage.simple_storage_box_crimson": "Caja de Almacenamiento Simple Carmesí",
+  "container.fxntstorage.simple_storage_box_crimson": "Caja de Almacenamiento Simple Carmesí",
+
+  "block.fxntstorage.simple_storage_box_warped": "Caja de Almacenamiento Simple Distorsionada",
+  "container.fxntstorage.simple_storage_box_warped": "Caja de Almacenamiento Simple Distorsionada",
+
+  "block.fxntstorage.storage_controller": "Controlador de Almacenamiento Simple",
+  "container.fxntstorage.storage_controller": "Controlador de Almacenamiento Simple",
+
+  "block.fxntstorage.storage_interface": "Interfaz de Almacenamiento Simple",
+  "container.fxntstorage.storage_interface": "Interfaz de Almacenamiento Simple",
+
+  "block.fxntstorage.passer_block": "Pasador",
+  "block.fxntstorage.smart_passer_block": "Pasador Inteligente",
+
+  "block.fxntstorage.back_pack": "Mochila de Hierro Industrial",
+  "container.fxntstorage.back_pack": "Mochila de Hierro Industrial",
+  "item.fxntstorage.back_pack": "Mochila de Hierro Industrial",
+
+  "block.fxntstorage.andesite_back_pack": "Mochila de Andesita",
+  "container.fxntstorage.andesite_back_pack": "Mochila de Andesita",
+  "item.fxntstorage.andesite_back_pack": "Mochila de Andesita",
+
+  "block.fxntstorage.copper_back_pack": "Mochila de Cobre",
+  "container.fxntstorage.copper_back_pack": "Mochila de Cobre",
+  "item.fxntstorage.copper_back_pack": "Mochila de Cobre",
+
+  "block.fxntstorage.brass_back_pack": "Mochila de Latón",
+  "container.fxntstorage.brass_back_pack": "Mochila de Latón",
+  "item.fxntstorage.brass_back_pack": "Mochila de Latón",
+
+  "block.fxntstorage.hardened_back_pack": "Mochila Endurecida",
+  "container.fxntstorage.hardened_back_pack": "Mochila Endurecida",
+  "item.fxntstorage.hardened_back_pack": "Mochila de Endurecida",
+
+  "item.fxntstorage.back_pack_blank_upgrade": "Plantilla de Mejora",
+  "item.fxntstorage.back_pack_magnet_upgrade": "Mejora de Imán de Mochila",
+  "item.fxntstorage.back_pack_magnet_upgrade_deactivated": "Mejora de Imán de Mochila [Desactivado]",
+  "item.fxntstorage.back_pack_pickblock_upgrade": "Mejora de Colección de Bloques de Mochila",
+  "item.fxntstorage.back_pack_pickblock_upgrade_deactivated": "Mejora de Colección de Bloques de Mochila [Desactivado]",
+  "item.fxntstorage.back_pack_itempickup_upgrade": "Mejora de Colección de Objetos de Mochila",
+  "item.fxntstorage.back_pack_itempickup_upgrade_deactivated": "Mejora de Colección de Objetos de Mochila [Desactivado]",
+  "item.fxntstorage.back_pack_flight_upgrade": "Mejora de Vuelo de Mochila",
+  "item.fxntstorage.back_pack_flight_upgrade_deactivated": "Mejora de Vuelo de Mochila [Desactivado]",
+  "item.fxntstorage.back_pack_refill_upgrade": "Mejora de Rellena de Mochila",
+  "item.fxntstorage.back_pack_refill_upgrade_deactivated": "Mejora de Rellena de Mochila [Desactivado]",
+  "item.fxntstorage.back_pack_feeder_upgrade": "Mejora de Alimentación de Mochila",
+  "item.fxntstorage.back_pack_feeder_upgrade_deactivated": "Mejora de Alimentación de Mochila [Desactivado]",
+  "item.fxntstorage.back_pack_toolswap_upgrade": "Mejora de Conmuta Herramientas de Mochila",
+  "item.fxntstorage.back_pack_toolswap_upgrade_deactivated": "Mejora de Conmuta Herramientas de Mochila [Desactivado]",
+    "item.fxntstorage.back_pack_falldamage_upgrade": "Mejora de Daño por Caída de Mochila",
+  "item.fxntstorage.back_pack_falldamage_upgrade_deactivated": "Mejora de Daño por Caída de Mochila [Desactivado]",
+
+  "item.fxntstorage.storage_box_void_upgrade": "Mejora de Vacío de Caja de Almacienamento Simple",
+  "item.fxntstorage.storage_box_capacity_upgrade": "Mejora de Capacidad de Caja de Almacienamento Simple",
+
+  "block.fxntstorage.storage_trim": "Marco de Almacienamento de Roble",
+  "block.fxntstorage.storage_trim_spruce": "Marco de Almacienamento de Abeto",
+  "block.fxntstorage.storage_trim_birch": "Marco de Almacienamento de Abedul",
+  "block.fxntstorage.storage_trim_jungle": "Marco de Almacienamento de la Jungla",
+  "block.fxntstorage.storage_trim_acacia": "Marco de Almacienamento de Acacia",
+  "block.fxntstorage.storage_trim_dark_oak": "Marco de Almacienamento de Roble Oscuro",
+  "block.fxntstorage.storage_trim_mangrove": "Marco de Almacienamento de Mangle",
+  "block.fxntstorage.storage_trim_cherry": "Marco de Almacienamento de Cerezo",
+  "block.fxntstorage.storage_trim_bamboo": "Marco de Almacienamento de Bambú",
+  "block.fxntstorage.storage_trim_crimson": "Marco de Almacienamento Carmesí",
+  "block.fxntstorage.storage_trim_warped": "Marco de Almacienamento Distorsionado",
+
+  "fxntstorage.tooltip.holdForControls": "Presiona [CTRL] para los Controles",
+  "fxntstorage.tooltip.holdForDescription": "Presiona [Shift] para lo Resumen",
+
+  "fxntstorage.storage_box_void_upgrade_exists": "Esta caja de almacenamiento ya contiene una mejora de vacío",
+  "fxntstorage.storage_box_capacity_upgrade_max": "Esta caja de almacenamiento ha alcanzado su capacidad máxima."
+}

--- a/src/main/resources/assets/fxntstorage/lang/pt_br.json
+++ b/src/main/resources/assets/fxntstorage/lang/pt_br.json
@@ -1,0 +1,126 @@
+{
+  "itemGroup.fxntstorage.main": "FXNT Storage",
+  "itemGroup.fxntstorage.create": "FXNT Storage Create",
+
+  "key.categories.fxntstorage": "FXNT Storage",
+  "key.fxntstorage.open_backpack": "Abrir Mochila",
+  "key.fxntstorage.clear_backpack_shape_cache": "Limpar Formato da Mochila Salvo",
+  "key.fxntstorage.backpack_hover": "Alternar Modo de Voo Pairado da Mochila",
+  "key.fxntstorage.toggle_upgrade": "Alternar Melhoria",
+
+  "block.fxntstorage.storage_box": "Caixa de Armazenamento de Ferro Industrial",
+  "container.fxntstorage.industrial_iron_storage_box": "Caixa de Armazenamento de Ferro Industrial",
+
+  "block.fxntstorage.andesite_storage_box": "Caixa de Armazenamento de Andesito",
+  "container.fxntstorage.andesite_storage_box": "Caixa de Armazenamento de Andesito",
+
+  "block.fxntstorage.copper_storage_box": "Caixa de Armazenamento de Cobre",
+  "container.fxntstorage.copper_storage_box": "Caixa de Armazenamento de Cobre",
+
+  "block.fxntstorage.brass_storage_box": "Caixa de Armazenamento de Latão",
+  "container.fxntstorage.brass_storage_box": "Caixa de Armazenamento de Latão",
+
+  "block.fxntstorage.hardened_storage_box": "Caixa de Armazenamento Temperada",
+  "container.fxntstorage.hardened_storage_box": "Caixa de Armazenamento Temperada",
+
+  "block.fxntstorage.simple_storage_box": "Caixa de Armazenamento de Carvalho Simples",
+  "container.fxntstorage.simple_storage_box": "Caixa de Armazenamento de Carvalho Simples",
+
+  "block.fxntstorage.simple_storage_box_spruce": "Caixa de Armazenamento de Pinheiro Simples",
+  "container.fxntstorage.simple_storage_box_spruce": "Caixa de Armazenamento de Pinheiro Simples",
+
+  "block.fxntstorage.simple_storage_box_birch": "Caixa de Armazenamento de Bétula Simples",
+  "container.fxntstorage.simple_storage_box_birch": "Caixa de Armazenamento de Bétula Simples",
+
+  "block.fxntstorage.simple_storage_box_jungle": "Caixa de Armazenamento da Selva Simples",
+  "container.fxntstorage.simple_storage_box_jungle": "Caixa de Armazenamento da Selva Simples",
+
+  "block.fxntstorage.simple_storage_box_acacia": "Caixa de Armazenamento de Acácia Simples",
+  "container.fxntstorage.simple_storage_box_acacia": "Caixa de Armazenamento de Acácia Simples",
+
+  "block.fxntstorage.simple_storage_box_dark_oak": "Caixa de Armazenamento de Carvalho Escuro Simples",
+  "container.fxntstorage.simple_storage_box_dark_oak": "Caixa de Armazenamento de Carvalho Escuro Simples",
+
+  "block.fxntstorage.simple_storage_box_mangrove": "Caixa de Armazenamento do Mangue Simples",
+  "container.fxntstorage.simple_storage_box_mangrove": "Caixa de Armazenamento do Mangue Simples",
+
+  "block.fxntstorage.simple_storage_box_cherry": "Caixa de Armazenamento de Cerejeira Simples",
+  "container.fxntstorage.simple_storage_box_cherry": "Caixa de Armazenamento de Cerejeira Simples",
+
+  "block.fxntstorage.simple_storage_box_bamboo": "Caixa de Armazenamento de Bambu Simples",
+  "container.fxntstorage.simple_storage_box_bamboo": "Caixa de Armazenamento de Bambu Simples",
+
+  "block.fxntstorage.simple_storage_box_crimson": "Caixa de Armazenamento Carmesim Simples",
+  "container.fxntstorage.simple_storage_box_crimson": "Caixa de Armazenamento Carmesim Simples",
+
+  "block.fxntstorage.simple_storage_box_warped": "Caixa de Armazenamento Distorcida Simples",
+  "container.fxntstorage.simple_storage_box_warped": "Caixa de Armazenamento Distorcida Simples",
+
+  "block.fxntstorage.storage_controller": "Controlador de Armazenamento Simples",
+  "container.fxntstorage.storage_controller": "Controlador de Armazenamento Simples",
+
+  "block.fxntstorage.storage_interface": "Interface de Armazenamento Simples",
+  "container.fxntstorage.storage_interface": "Interface de Armazenamento Simples",
+
+  "block.fxntstorage.passer_block": "Passador",
+  "block.fxntstorage.smart_passer_block": "Passador Inteligente",
+
+  "block.fxntstorage.back_pack": "Mochila de Ferro Industrial",
+  "container.fxntstorage.back_pack": "Mochila de Ferro Industrial",
+  "item.fxntstorage.back_pack": "Mochila de Ferro Industrial",
+
+  "block.fxntstorage.andesite_back_pack": "Mochila de Andesito",
+  "container.fxntstorage.andesite_back_pack": "Mochila de Andesito",
+  "item.fxntstorage.andesite_back_pack": "Mochila de Andesito",
+
+  "block.fxntstorage.copper_back_pack": "Mochila de Cobre",
+  "container.fxntstorage.copper_back_pack": "Mochila de Cobre",
+  "item.fxntstorage.copper_back_pack": "Mochila de Cobre",
+
+  "block.fxntstorage.brass_back_pack": "Mochila de Latão",
+  "container.fxntstorage.brass_back_pack": "Mochila de Latão",
+  "item.fxntstorage.brass_back_pack": "Mochila de Latão",
+
+  "block.fxntstorage.hardened_back_pack": "Mochila Temperada",
+  "container.fxntstorage.hardened_back_pack": "Mochila Temperada",
+  "item.fxntstorage.hardened_back_pack": "Mochila Temperada",
+
+  "item.fxntstorage.back_pack_blank_upgrade": "Modelo de Melhoria",
+  "item.fxntstorage.back_pack_magnet_upgrade": "Melhoria de Ímã para Mochila",
+  "item.fxntstorage.back_pack_magnet_upgrade_deactivated": "Melhoria de Ímã para Mochila [Desativado]",
+  "item.fxntstorage.back_pack_pickblock_upgrade": "Melhoria de Coleta de Blocos para Mochila",
+  "item.fxntstorage.back_pack_pickblock_upgrade_deactivated": "Melhoria de Coleta de Blocos para Mochila [Desativado]",
+  "item.fxntstorage.back_pack_itempickup_upgrade": "Melhoria de Coleta de Itens para Mochila",
+  "item.fxntstorage.back_pack_itempickup_upgrade_deactivated": "Melhoria de Coleta de Itens para Mochila [Desativado]",
+  "item.fxntstorage.back_pack_flight_upgrade": "Melhoria de Voo para Mochila",
+  "item.fxntstorage.back_pack_flight_upgrade_deactivated": "Melhoria de Voo para Mochila [Desativado]",
+  "item.fxntstorage.back_pack_refill_upgrade": "Melhoria de Reabastecimento para Mochila",
+  "item.fxntstorage.back_pack_refill_upgrade_deactivated": "Melhoria de Reabastecimento para Mochila [Desativado]",
+  "item.fxntstorage.back_pack_feeder_upgrade": "Melhoria de Alimentação para Mochila",
+  "item.fxntstorage.back_pack_feeder_upgrade_deactivated": "Melhoria de Alimentação para Mochila [Desativado]",
+  "item.fxntstorage.back_pack_toolswap_upgrade": "Melhoria de Troca de Ferramenta para Mochila",
+  "item.fxntstorage.back_pack_toolswap_upgrade_deactivated": "Melhoria de Troca de Ferramenta para Mochila [Desativado]",
+  "item.fxntstorage.back_pack_falldamage_upgrade": "Melhoria de Dano de Queda para Mochila",
+  "item.fxntstorage.back_pack_falldamage_upgrade_deactivated": "Melhoria de Dano de Queda para Mochila [Desativado]",
+
+  "item.fxntstorage.storage_box_void_upgrade": "Melhoria de Nulo para Caixa de Armazenamento Simples",
+  "item.fxntstorage.storage_box_capacity_upgrade": "Melhoria de Capacidade para Caixa de Armazenamento Simples",
+
+  "block.fxntstorage.storage_trim": "Moldura de Armazenamento de Carvalho",
+  "block.fxntstorage.storage_trim_spruce": "Moldura de Armazenamento de Pinheiro",
+  "block.fxntstorage.storage_trim_birch": "Moldura de Armazenamento de Bétula",
+  "block.fxntstorage.storage_trim_jungle": "Moldura de Armazenamento da Selva",
+  "block.fxntstorage.storage_trim_acacia": "Moldura de Armazenamento de Acácia",
+  "block.fxntstorage.storage_trim_dark_oak": "Moldura de Armazenamento de Carvalho Escuro",
+  "block.fxntstorage.storage_trim_mangrove": "Moldura de Armazenamento do Mangue",
+  "block.fxntstorage.storage_trim_cherry": "Moldura de Armazenamento de Cerejeira",
+  "block.fxntstorage.storage_trim_bamboo": "Moldura de Armazenamento de Bambu",
+  "block.fxntstorage.storage_trim_crimson": "Moldura de Armazenamento Carmesim",
+  "block.fxntstorage.storage_trim_warped": "Moldura de Armazenamento Distorcido",
+
+  "fxntstorage.tooltip.holdForControls": "Segure [CTRL] para Controles",
+  "fxntstorage.tooltip.holdForDescription": "Segure [Shift] para Resumo",
+
+  "fxntstorage.storage_box_void_upgrade_exists": "Esta caixa de armazenamento já possui uma melhoria de nulo",
+  "fxntstorage.storage_box_capacity_upgrade_max": "Esta caixa de armazenamento já alcançou sua capacidade máxima"
+}


### PR DESCRIPTION
This PR adds translation JSON files for both Brazilian Portuguese and Argentinian Spanish.  I've specified the locales for Brazil and Argentine but they can pretty much be used for any other pt or es translations.

Note that Spanish is not my first language so I'd recommend a review from a native. 